### PR TITLE
Update Title Format and Header Spacing

### DIFF
--- a/Lecture_template.md
+++ b/Lecture_template.md
@@ -2,8 +2,7 @@
 # Lecture #: Topic   
 (mm/dd/2021)
 
-
-#### Topic 1
+## Topic 1
 
 Text-body 
 ...  
@@ -25,19 +24,20 @@ Explanations of things.
 ...  
 ...  
 
+- Bulleted Points
+	+ With more details
 
 **Maybe important detail**
 
-#### Topic 2
+## Topic 2
 
-**Maybe this one is a list of steps or commands**
-
+### Maybe this one is a list of steps or commands
 * listed item
 * listed item
 * **command**: explanation
 * **command -flag**: explanation
 
-#### Topic 3
+## Topic 3
 
 ```bash
 > Example bash commands


### PR DESCRIPTION
Fix spacing between header and rest of notes to be a single line. Update
topic titles from four hashes (####) to two (##). This allows for
greater granularity of topic breakdown via the use of triple or
quadruple hashes for subsections. This format is also more consistent
with previous commits such as 66c1f81 for Day2.md, f5ff403 from
Lecture_01.md, and 48f0171 from Lecture_04.md.

Add a bullet point with an indented subsection to provide support for
these as well.