### PR TITLE
Add date and fix bullet point formatting for lecture 8 (new branch)

### DIFF
--- a/Lecture_08.md
+++ b/Lecture_08.md
@@ -1,10 +1,11 @@
 #### CS 340 Class Notes Summer 2021
 # Lecture 08: GitHub and Repositories
-(mm/dd/2021)
+(05/19/2021)
 
 
 ## Information in Commit
-Commit messages can be several lines long (and should be??)
+Commit messages can be several lines long (and should be??)  
+
 - Describe the problem being fixed (can reference the bug report number) but description should still be standalone
 - Don't assume access to outside resources
 - Describe why the changes are being made


### PR DESCRIPTION
The date was added to the Lecture_08 file from the date listed on
Sakai. Also, there was a problem with the bullet points in the file,
so I added a line to make the formatting work. This is the same as
an earlie commit, but on a new branch so that it has no connection to
other unmerged files.

The old branch was discarded so that merged files don't get accidentally 
deleted with an accepted PR. 